### PR TITLE
v0.0.2-1: fix for all_comb_treat length comparison.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: delboy
 Title: Differential-representation analysis by Elastic-net
     Logistic regression with BinOmial-thinning validitY tests
-Version: 0.0.2
+Version: 0.0.2-1
 Authors@R: 
     person(given = "Alex",
            family = "Kalinka",

--- a/R/all_combinations_treat_samples.R
+++ b/R/all_combinations_treat_samples.R
@@ -10,7 +10,7 @@
 #' @importFrom combinat combn
 all_combinations_treat_samples <- function(samples, num_treat){
   tryCatch({
-    if(num_treat >= samples)
+    if(num_treat >= length(samples))
       stop(paste("'length(num_treat)' must be less than length(samples):",length(num_treat),"vs",length(samples)))
     comb <- combinat::combn(samples, num_treat)
     return(comb)

--- a/R/evaluate_performance_deg_calls.R
+++ b/R/evaluate_performance_deg_calls.R
@@ -84,8 +84,8 @@ evaluate_performance_deg_calls <- function(data, group_1, group_2, gene_column, 
 
       # 11. Run Elastic-net logistic regression on bthin data.
       elnet.lr <- delboy::run_elnet_logistic_reg(as.matrix(data.elnet[,3:ncol(data.elnet)]),
-                                               factor(data.elnet$treat),
-                                               alpha = alpha)
+                                                 factor(data.elnet$treat),
+                                                 alpha = alpha)
       
       # 12. Extract performance statistics.
       perf_stats <- delboy::perf_stats_deg(elnet.lr, deseq2_res, lfc_samp)

--- a/R/perf_stats_deg.R
+++ b/R/perf_stats_deg.R
@@ -48,7 +48,7 @@ perf_stats_deg <- function(delboy_res, deseq2_res, lfc_samp, padj_cutoff = 0.1){
 
     pstats <- rbind(delboy_stats, deseq2_stats)
   },
-  error = function(e) stop(paste("unable to extract performance stats for RNAseq data:",e))
+  error = function(e) stop(paste("unable to extract performance stats for DEG results:",e))
   )
   return(pstats)
 }

--- a/R/print.delboy.R
+++ b/R/print.delboy.R
@@ -16,6 +16,6 @@ print.delboy <- function(x, ...){
             "\nFDR (%):\n  delboy: ",round(x$performance_stats_corr_FP$FDR.percent[1],3),
             " (",x$performance_stats_corr_FP$Num_false_calls[1]," genes)",
             "\n  DESeq2: ",round(x$performance_stats_corr_FP$FDR.percent[2],3),
-            " (",x$performance_stats_corr_FP$Num_false_calls[2]," genes)",
+            " (",x$performance_stats_corr_FP$Num_false_calls[2]," genes)\n",
             sep=""))
 }

--- a/R/run_delboy.R
+++ b/R/run_delboy.R
@@ -31,6 +31,7 @@
 #' @importFrom utils read.delim
 #' @importFrom crayon blue red green magenta
 #' @md
+#' @author Alex T. Kalinka <alex.t.kalinka@@gmail.com>
 #' @references
 #' * Kalinka, A. T. 2020. Improving the sensitivity of differential-expression analyses for under-powered RNA-seq experiments. bioRxiv [10.1101/2020.10.15.340737](https://doi.org/10.1101/2020.10.15.340737).
 #' * Patro, R. et al. 2017. Salmon provides fast and bias-aware quantification of transcript expression. Nature Methods 14: 417-419.

--- a/R/run_delboy.R
+++ b/R/run_delboy.R
@@ -31,7 +31,7 @@
 #' @importFrom utils read.delim
 #' @importFrom crayon blue red green magenta
 #' @md
-#' @author Alex T. Kalinka <alex.t.kalinka@@gmail.com>
+#' @author Alex T. Kalinka, \email{alex.t.kalinka@@gmail.com}
 #' @references
 #' * Kalinka, A. T. 2020. Improving the sensitivity of differential-expression analyses for under-powered RNA-seq experiments. bioRxiv [10.1101/2020.10.15.340737](https://doi.org/10.1101/2020.10.15.340737).
 #' * Patro, R. et al. 2017. Salmon provides fast and bias-aware quantification of transcript expression. Nature Methods 14: 417-419.

--- a/R/smooth_decision_boundary.R
+++ b/R/smooth_decision_boundary.R
@@ -35,6 +35,12 @@
 #' @importFrom magrittr %<>%
 smooth_decision_boundary <- function(db, entry_point = 1.25){
   tryCatch({
+    # Check if entry point makes sense.
+    if(sum(db$log10_baseExpr <= entry_point) <= 10){
+      entry_point <- median(db$log10_baseExpr, na.rm = T)
+      .db_message(paste("using DB smoothing entry point of",entry_point),"blue")
+    }
+    
     db_low <- db %>%
       dplyr::filter(log10_baseExpr <= entry_point) %>%
       dplyr::arrange(dplyr::desc(log10_baseExpr))

--- a/man/run_delboy.Rd
+++ b/man/run_delboy.Rd
@@ -50,3 +50,6 @@ Performs a differential-representation analysis using an elastic-net logistic re
 \seealso{
 \code{\link{hits}}, \code{\link{plot.delboy}}, \code{\link{get_performance_stats}}, \code{\link{get_deseq2_results}}
 }
+\author{
+Alex T. Kalinka \href{mailto:alex.t.kalinka@gmail.com}{alex.t.kalinka@gmail.com}
+}

--- a/man/run_delboy.Rd
+++ b/man/run_delboy.Rd
@@ -51,5 +51,5 @@ Performs a differential-representation analysis using an elastic-net logistic re
 \code{\link{hits}}, \code{\link{plot.delboy}}, \code{\link{get_performance_stats}}, \code{\link{get_deseq2_results}}
 }
 \author{
-Alex T. Kalinka \href{mailto:alex.t.kalinka@gmail.com}{alex.t.kalinka@gmail.com}
+Alex T. Kalinka, \email{alex.t.kalinka@gmail.com}
 }


### PR DESCRIPTION
**v0.0.2-1**: Some small fixes:

* `all_combinations_treat_samples`: `num_treat` now compared to `length(samples)`.
* `smooth_decision_boundary`: Check whether entry point for smoothing makes sense: if < 10 log10 expr values below entry point then take the median and report this value on the console.